### PR TITLE
Introduce the HTTP01 challenge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:3.3
 MAINTAINER <jan@rancher.com>
 
+EXPOSE 80
+
 RUN apk add --no-cache ca-certificates
 
 ENV LETSENCRYPT_RELEASE v0.3.0

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,8 @@
 FROM alpine:3.3
 MAINTAINER Jan Broer <jan@festplatte.eu.org>
 
+EXPOSE 80
+
 RUN apk add --no-cache ca-certificates
 
 ADD build/rancher-letsencrypt-linux-amd64 /usr/bin/rancher-letsencrypt

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A [Rancher](http://rancher.com/rancher/) service that obtains free SSL/TLS certi
 
 #### Requirements
 * Rancher Server >= v0.63.0
-* Existing account with one of the supported DNS providers:
+* If using a DNS-based challenge, existing account with one of the supported DNS providers:
   * `AWS Route 53`
   * `CloudFlare`
   * `DigitalOcean`
@@ -24,6 +24,7 @@ A [Rancher](http://rancher.com/rancher/) service that obtains free SSL/TLS certi
   * `Dyn`
   * `Vultr`
   * `Ovh`
+* If using the HTTP challenge, a proxy that routes `example.com/.well-known/acme-challenge` to `rancher-letsencrypt`.
 
 ### How to use
 
@@ -96,7 +97,22 @@ To finish, when you start this container add the following environment variable:
 - `PROVIDER`: Ovh
 - `OVH_APPLICATION_KEY`: your key generated in previous step
 - `OVH_APPLICATION_SECRET`: your secret generated in previous step
-- `OVH_CONSUMER_KEY`: your consumer key generated in previous step 
+- `OVH_CONSUMER_KEY`: your consumer key generated in previous step
+
+#### HTTP
+
+If you prefer not to use a DNS-based challenge
+or your provider is not supported, you can use the HTTP challenge.
+
+Simply set the following option:
+- `PROVIDER`: HTTP
+
+With this you'll have to make sure that HTTP
+requests to `example.com/.well-known/acme-challenge` get redirected
+to your `rancher-letsencrypt` instance. You can use a reverse proxy, like
+the Rancher Load Balancer for that:
+
+![Rancher Load Balancer LetsEncrypt Targets](https://cloud.githubusercontent.com/assets/198988/22224463/0d1eb4aa-e1bf-11e6-955c-5f0d085ce8cd.png)
 
 ### Building the image
 

--- a/context.go
+++ b/context.go
@@ -86,7 +86,6 @@ func (c *Context) InitContext() {
 		OvhApplicationKey:    getEnvOption("OVH_APPLICATION_KEY", false),
 		OvhApplicationSecret: getEnvOption("OVH_APPLICATION_SECRET", false),
 		OvhConsumerKey:       getEnvOption("OVH_CONSUMER_KEY", false),
-		HTTPWebrootPath:      getEnvOption("HTTP_WEBROOT_PATH", false),
 	}
 
 	c.Acme, err = letsencrypt.NewClient(emailParam, keyType, apiVersion, providerOpts)

--- a/context.go
+++ b/context.go
@@ -71,7 +71,7 @@ func (c *Context) InitContext() {
 	}
 
 	providerOpts := letsencrypt.ProviderOpts{
-		Provider:             letsencrypt.DnsProvider(providerParam),
+		Provider:             letsencrypt.Provider(providerParam),
 		CloudflareEmail:      getEnvOption("CLOUDFLARE_EMAIL", false),
 		CloudflareKey:        getEnvOption("CLOUDFLARE_KEY", false),
 		DoAccessToken:        getEnvOption("DO_ACCESS_TOKEN", false),
@@ -86,6 +86,7 @@ func (c *Context) InitContext() {
 		OvhApplicationKey:    getEnvOption("OVH_APPLICATION_KEY", false),
 		OvhApplicationSecret: getEnvOption("OVH_APPLICATION_SECRET", false),
 		OvhConsumerKey:       getEnvOption("OVH_CONSUMER_KEY", false),
+		HTTPWebrootPath:      getEnvOption("HTTP_WEBROOT_PATH", false),
 	}
 
 	c.Acme, err = letsencrypt.NewClient(emailParam, keyType, apiVersion, providerOpts)

--- a/letsencrypt/providers.go
+++ b/letsencrypt/providers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/xenolf/lego/providers/dns/ovh"
 	"github.com/xenolf/lego/providers/dns/route53"
 	"github.com/xenolf/lego/providers/dns/vultr"
-	"github.com/xenolf/lego/providers/http/webroot"
 )
 
 // ProviderOpts is used to configure the DNS provider
@@ -213,16 +212,7 @@ func makeOvhProvider(opts ProviderOpts) (lego.ChallengeProvider, error) {
 
 // returns a preconfigured HTTP lego.ChallengeProvider
 func makeHTTPProvider(opts ProviderOpts) (lego.ChallengeProvider, error) {
-	if len(opts.HTTPWebrootPath) == 0 {
-		return nil, fmt.Errorf("HTTP webroot path is not set")
-	}
+	provider := lego.NewHTTPProviderServer("", "")
 
-	webrootPath := opts.HTTPWebrootPath
-	maybeCreatePath(webrootPath)
-
-	provider, err := webroot.NewHTTPProvider(webrootPath)
-	if err != nil {
-		return nil, err
-	}
 	return provider, nil
 }

--- a/letsencrypt/providers.go
+++ b/letsencrypt/providers.go
@@ -46,9 +46,6 @@ type ProviderOpts struct {
 	OvhApplicationKey    string
 	OvhApplicationSecret string
 	OvhConsumerKey       string
-
-	// HTTP challenge options
-	HTTPWebrootPath string
 }
 
 type Provider string

--- a/letsencrypt/providers.go
+++ b/letsencrypt/providers.go
@@ -65,19 +65,19 @@ const (
 )
 
 type ProviderFactory struct {
-	factory interface{}
+	factory   interface{}
 	challenge lego.Challenge
 }
 
 var providerFactory = map[Provider]ProviderFactory{
-	CLOUDFLARE:   ProviderFactory{makeCloudflareProvider,   lego.DNS01},
+	CLOUDFLARE:   ProviderFactory{makeCloudflareProvider, lego.DNS01},
 	DIGITALOCEAN: ProviderFactory{makeDigitalOceanProvider, lego.DNS01},
-	ROUTE53:      ProviderFactory{makeRoute53Provider,      lego.DNS01},
-	DNSIMPLE:     ProviderFactory{makeDNSimpleProvider,     lego.DNS01},
-	DYN:          ProviderFactory{makeDynProvider,          lego.DNS01},
-	VULTR:        ProviderFactory{makeVultrProvider,        lego.DNS01},
-	OVH:          ProviderFactory{makeOvhProvider,          lego.DNS01},
-	HTTP:         ProviderFactory{makeHTTPProvider,         lego.HTTP01},
+	ROUTE53:      ProviderFactory{makeRoute53Provider, lego.DNS01},
+	DNSIMPLE:     ProviderFactory{makeDNSimpleProvider, lego.DNS01},
+	DYN:          ProviderFactory{makeDynProvider, lego.DNS01},
+	VULTR:        ProviderFactory{makeVultrProvider, lego.DNS01},
+	OVH:          ProviderFactory{makeOvhProvider, lego.DNS01},
+	HTTP:         ProviderFactory{makeHTTPProvider, lego.HTTP01},
 }
 
 func getProvider(opts ProviderOpts) (lego.ChallengeProvider, lego.Challenge, error) {


### PR DESCRIPTION
This pull request adds a new provider called `HTTP` to the list, allowing you to use this Rancher  Letsencrypt integration with yet unsupported DNS providers or where you don't have API access to your DNS records. Fixes #28.

The only thing that needs to be considered is that you'll have to redirect all traffic to `http://your-domain:80/.well-known/acme-challenge` to your rancher-letsencrypt service, in order for it to be able to serve the challenge files. This can be done using the built-in Rancher load balancer.

<img width="919" alt="screen shot 2016-10-10 at 23 53 00" src="https://cloud.githubusercontent.com/assets/198988/19252352/ba6379b6-8f44-11e6-9842-2026e0c33ce2.png">

If you want to test this, there are a couple of steps necessary:
1. Make sure you have a working Go environment
2. Clone the branch
3. `make build`
4. remove the `-debug`arg from `Dockerfile.dev`
5. `make image`
6. Use that image and make sure you set `PROVIDER=HTTP`

Or, if you trust me, use my image [`davidknezic/rancher-letsencrypt:dev-a13546f`](https://hub.docker.com/r/davidknezic/rancher-letsencrypt/).

I don't consider this ready to merge, this is what's still missing:
- [x] fix formatting with `gofmt`
- [x] testing (seems to work for everyone in #28 and here)
- [x] feedback @janeczku 
- [x] extend the docs/README
