### PR TITLE
Add PowerDNS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A [Rancher](http://rancher.com/rancher/) service that obtains free SSL/TLS certi
   * `Gandi`
   * `NS1`
   * `Ovh`
+  * `PowerDNS`
   * `Vultr`
 
 * If using the HTTP challenge, a reverse proxy that routes `example.com/.well-known/acme-challenge` to `rancher-letsencrypt`. 

--- a/context.go
+++ b/context.go
@@ -124,6 +124,8 @@ func (c *Context) InitContext() {
 		OvhApplicationKey:    getEnvOption("OVH_APPLICATION_KEY", false),
 		OvhApplicationSecret: getEnvOption("OVH_APPLICATION_SECRET", false),
 		OvhConsumerKey:       getEnvOption("OVH_CONSUMER_KEY", false),
+		PowerDNSUrl:          getEnvOption("PDNS_URL", false),
+		PowerDNSKey:          getEnvOption("PDNS_KEY", false),
 		GandiApiKey:          getEnvOption("GANDI_API_KEY", false),
 		NS1ApiKey:            getEnvOption("NS1_API_KEY", false),
 	}


### PR DESCRIPTION
Hi, i added the support for PowerDNS provider (that was already supported by lego).
The new provider name is "PowerDNS", the 2 new environments are:
- PDNS_URL: The url for PowerDNS API. Ex. http://pdns:8081
- PDNS_KEY: The PowerDNS API key

I tested with our PowerDNS and it work.

Thanks.